### PR TITLE
Add the cvv result to the billing response.

### DIFF
--- a/app/models/solidus/gateway/braintree_gateway.rb
+++ b/app/models/solidus/gateway/braintree_gateway.rb
@@ -154,7 +154,8 @@ module Solidus
       {}.tap do |results_hash|
         results_hash.merge!({
           authorization: result.transaction.id,
-          avs_result: { code: result.transaction.avs_street_address_response_code }
+          avs_result: { code: result.transaction.avs_street_address_response_code },
+          cvv_result: result.transaction.cvv_response_code
         }) if result.success?
       end
     end

--- a/spec/solidus/gateway/braintree_gateway_spec.rb
+++ b/spec/solidus/gateway/braintree_gateway_spec.rb
@@ -88,6 +88,7 @@ describe Solidus::Gateway::BraintreeGateway, :vcr do
           expect(capture).to be_success
           expect(capture.authorization).to be_present
           expect(capture.avs_result["code"]).to eq "M"
+          expect(capture.cvv_result["code"]).to eql("I")
         end
       end
 
@@ -153,11 +154,13 @@ describe Solidus::Gateway::BraintreeGateway, :vcr do
       expect(auth).to be_success
       expect(auth.authorization).to be_present
       expect(auth.avs_result["code"]).to eq "I"
+      expect(auth.cvv_result["code"]).to eq "I"
 
       capture = payment_method.capture(5000, auth.authorization, {})
       expect(capture).to be_success
       expect(capture.authorization).to be_present
       expect(capture.avs_result["code"]).to eq "I"
+      expect(capture.cvv_result["code"]).to eq "I"
     end
 
     it "succeeds capture on pending settlement" do


### PR DESCRIPTION
This is automatically handled in solidus and used for the
cvv_response_code field on payments, if it's present.

Cannot be merged pending an issue with paypal.
